### PR TITLE
Add support for time.Duration in default values

### DIFF
--- a/internal/parser/defaultValues/defaultValues.go
+++ b/internal/parser/defaultValues/defaultValues.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type DefaultInfo struct {
@@ -99,6 +100,13 @@ func parseDefaultValues(t reflect.Type, parentBindKey string, lines *[]DefaultIn
 			}
 
 			defaultValue = mapPtr.Elem().Interface()
+		} else if field.Type == reflect.TypeOf(time.Duration(0)) {
+			durationVal, err := time.ParseDuration(defaultValStr)
+			if err != nil {
+				fmt.Printf("cannot parse default value \"%s\" as duration: %s", defaultValStr, err)
+				continue
+			}
+			defaultValue = durationVal
 		} else {
 			// Processing of single values (primitives)
 			switch fieldKind {

--- a/internal/parser/defaultValues/defaultValues_test.go
+++ b/internal/parser/defaultValues/defaultValues_test.go
@@ -2,6 +2,7 @@ package defaultValues
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ func TestGetDefaultValues(t *testing.T) {
 		Timeout  float64           `mapstructure:"timeout" default:"30.5"`
 		Tags     []string          `mapstructure:"tags" default:"[\"tag1\",\"tag2\"]"`
 		Settings map[string]string `mapstructure:"settings" default:"{\"key1\":\"value1\"}"`
+		Duration time.Duration     `mapstructure:"duration" default:"1m5s"`
 	}
 
 	cfg := Config{}
@@ -28,6 +30,7 @@ func TestGetDefaultValues(t *testing.T) {
 		{BindKey: "timeout", DefaultValue: 30.5},
 		{BindKey: "tags", DefaultValue: []string{"tag1", "tag2"}},
 		{BindKey: "settings", DefaultValue: map[string]string{"key1": "value1"}},
+		{BindKey: "duration", DefaultValue: 1*time.Minute + 5*time.Second},
 	}
 
 	assert.EqualValues(t, expected, defaults)


### PR DESCRIPTION
This PR adds support for parsing Go-style duration strings (e.g. "10s", "2m") as `time.Duration` when using config default values.

Motivation:
- Easier and more flexible configuration of timeouts and intervals
- Standard and safe behavior using `time.ParseDuration`

Example usage:
```go
type Config struct {
    Interval time.Duration `mapstructure:"interval" default:"5s"`
}