### PR TITLE
Enhance validation to support both standard and Robfig cron descriptor expressions

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -177,8 +177,13 @@ func IsValidCronExpression(expression string, fieldName string, isWithSeconds bo
 	return true, nil
 }
 
-// IsValidRobfigCronDescriptor проверяет валидность спец-выражений cron библиотеки robfig/cron (например, "@every 2m", "@hourly").
-func IsValidRobfigCronDescriptor(expression string, fieldName string) (bool, error) {
+// IsValidRobfigCronExpression проверяет валидность cron-выражений,
+// поддерживаемых библиотекой robfig/cron
+// Поддерживаются:
+//   - стандартные crontab-выражения из 5 полей (минуты, часы, день месяца, месяц, день недели),
+//     например: "0 12 * * ?" или "* * * * *"
+//   - специальные дескрипторы, например: "@every 2m", "@hourly", "@midnight"
+func IsValidRobfigCronExpression(expression string, fieldName string) (bool, error) {
 	_, err := cron.ParseStandard(expression)
 	if err != nil {
 		return false, fmt.Errorf("%s cron выражение '%s' недействительно: %v", fieldName, expression, err)

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -176,3 +176,12 @@ func IsValidCronExpression(expression string, fieldName string, isWithSeconds bo
 	}
 	return true, nil
 }
+
+// IsValidRobfigCronDescriptor проверяет валидность спец-выражений cron библиотеки robfig/cron (например, "@every 2m", "@hourly").
+func IsValidRobfigCronDescriptor(expression string, fieldName string) (bool, error) {
+	_, err := cron.ParseStandard(expression)
+	if err != nil {
+		return false, fmt.Errorf("%s cron выражение '%s' недействительно: %v", fieldName, expression, err)
+	}
+	return true, nil
+}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -324,6 +324,71 @@ func TestIsValidCronExpression(t *testing.T) {
 	}
 }
 
+// TestIsValidRobfigCronDescriptor тестирует функцию IsValidRobfigCronDescriptor.
+func TestIsValidRobfigCronDescriptor(t *testing.T) {
+	tests := []struct {
+		name          string
+		fieldName     string
+		expression    string
+		expectedValid bool
+		expectedErr   string
+	}{
+		{
+			name:          "Valid @every expression",
+			fieldName:     "SyncJob",
+			expression:    "@every 2m",
+			expectedValid: true,
+			expectedErr:   "",
+		},
+		{
+			name:          "Valid @hourly expression",
+			fieldName:     "HourlyTask",
+			expression:    "@hourly",
+			expectedValid: true,
+			expectedErr:   "",
+		},
+		{
+			name:          "Invalid descriptor format",
+			fieldName:     "BrokenJob",
+			expression:    "@evry 5m",
+			expectedValid: false,
+			expectedErr:   "BrokenJob cron выражение '@evry 5m' недействительно:",
+		},
+		{
+			name:          "Invalid cron format in descriptor",
+			fieldName:     "BadIntervalJob",
+			expression:    "@every wrong",
+			expectedValid: false,
+			expectedErr:   "BadIntervalJob cron выражение '@every wrong' недействительно:",
+		},
+		{
+			name:          "Totally invalid string",
+			fieldName:     "GarbageJob",
+			expression:    "not a cron",
+			expectedValid: false,
+			expectedErr:   "GarbageJob cron выражение 'not a cron' недействительно:",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			valid, err := IsValidRobfigCronDescriptor(test.expression, test.fieldName)
+			if valid != test.expectedValid {
+				t.Errorf("expected validity %v, got %v", test.expectedValid, valid)
+			}
+			if err != nil && test.expectedErr == "" {
+				t.Errorf("expected no error, got error %v", err)
+			}
+			if err == nil && test.expectedErr != "" {
+				t.Errorf("expected error %s, got no error", test.expectedErr)
+			}
+			if err != nil && test.expectedErr != "" && !startsWith(err.Error(), test.expectedErr) {
+				t.Errorf("expected error message to start with '%s', got '%s'", test.expectedErr, err.Error())
+			}
+		})
+	}
+}
+
 // startsWith checks if a string starts with a given prefix.
 func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -324,8 +324,8 @@ func TestIsValidCronExpression(t *testing.T) {
 	}
 }
 
-// TestIsValidRobfigCronDescriptor тестирует функцию IsValidRobfigCronDescriptor.
-func TestIsValidRobfigCronDescriptor(t *testing.T) {
+// TestIsValidRobfigCronExpression тестирует функцию IsValidRobfigCronExpression.
+func TestIsValidRobfigCronExpression(t *testing.T) {
 	tests := []struct {
 		name          string
 		fieldName     string
@@ -348,6 +348,20 @@ func TestIsValidRobfigCronDescriptor(t *testing.T) {
 			expectedErr:   "",
 		},
 		{
+			name:          "Valid standard cron expression",
+			fieldName:     "DailyJob",
+			expression:    "0 0 * * *",
+			expectedValid: true,
+			expectedErr:   "",
+		},
+		{
+			name:          "Valid standard cron with wildcard",
+			fieldName:     "WildcardJob",
+			expression:    "* * * * *",
+			expectedValid: true,
+			expectedErr:   "",
+		},
+		{
 			name:          "Invalid descriptor format",
 			fieldName:     "BrokenJob",
 			expression:    "@evry 5m",
@@ -362,6 +376,13 @@ func TestIsValidRobfigCronDescriptor(t *testing.T) {
 			expectedErr:   "BadIntervalJob cron выражение '@every wrong' недействительно:",
 		},
 		{
+			name:          "Invalid standard cron expression",
+			fieldName:     "BadCronJob",
+			expression:    "0 0 0 *",
+			expectedValid: false,
+			expectedErr:   "BadCronJob cron выражение '0 0 0 *' недействительно:",
+		},
+		{
 			name:          "Totally invalid string",
 			fieldName:     "GarbageJob",
 			expression:    "not a cron",
@@ -372,7 +393,7 @@ func TestIsValidRobfigCronDescriptor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			valid, err := IsValidRobfigCronDescriptor(test.expression, test.fieldName)
+			valid, err := IsValidRobfigCronExpression(test.expression, test.fieldName)
 			if valid != test.expectedValid {
 				t.Errorf("expected validity %v, got %v", test.expectedValid, valid)
 			}


### PR DESCRIPTION
### Summary

This PR adds a new helper `IsValidRobfigCronExpression` that validates both:
- Standard crontab expressions with 5 fields (minute, hour, day of month, month, day of week)
- Special Robfig cron descriptors such as @every, @hourly, @midnight

The method provides clear error messages when expressions are invalid, ensuring better configuration validation coverage.

### What's included

- New helper:

```
IsValidRobfigCronExpression(expression string, fieldName string) (bool, error)
```

- Unit tests covering:
    - Valid and invalid standard cron expressions
    - Valid and invalid Robfig special descriptors
    - Completely malformed input strings

### Motivation

Robfig's cron package supports special expressions that begin with `@`, which were previously not handled separately. This update ensures better validation coverage and clearer diagnostics during configuration validation.
